### PR TITLE
Improve popup UI with dark mode toggle

### DIFF
--- a/src/common/App.tsx
+++ b/src/common/App.tsx
@@ -1,4 +1,10 @@
-import { Box, ChakraProvider, Heading, HStack } from '@chakra-ui/react';
+import {
+  Box,
+  ChakraProvider,
+  Heading,
+  HStack,
+  ColorModeScript,
+} from '@chakra-ui/react';
 import React from 'react';
 import { useAppState } from '../state/store';
 import ModelDropdown from './ModelDropdown';
@@ -6,6 +12,8 @@ import ProviderDropdown from './ProviderDropdown';
 import SetAPIKey from './SetAPIKey';
 import TaskUI from './TaskUI';
 import OptionsDropdown from './OptionsDropdown';
+import ThemeToggle from './ThemeToggle';
+import theme from '../theme';
 import logo from '../assets/img/icon-128.png';
 
 const App = () => {
@@ -18,7 +26,8 @@ const App = () => {
     (settings.provider === 'ollama' && settings.ollamaUrl);
 
   return (
-    <ChakraProvider>
+    <ChakraProvider theme={theme}>
+      <ColorModeScript initialColorMode={theme.config.initialColorMode} />
       <Box p="8" fontSize="lg" w="full">
         <HStack mb={4} alignItems="center">
           <img
@@ -35,6 +44,7 @@ const App = () => {
           <HStack spacing={2}>
             <ProviderDropdown />
             <ModelDropdown />
+            <ThemeToggle />
             <OptionsDropdown />
           </HStack>
         </HStack>

--- a/src/common/ThemeToggle.tsx
+++ b/src/common/ThemeToggle.tsx
@@ -1,0 +1,18 @@
+import { IconButton, useColorMode, useColorModeValue } from '@chakra-ui/react';
+import { MoonIcon, SunIcon } from '@chakra-ui/icons';
+import React from 'react';
+
+const ThemeToggle = () => {
+  const { toggleColorMode } = useColorMode();
+  const SwitchIcon = useColorModeValue(MoonIcon, SunIcon);
+  return (
+    <IconButton
+      aria-label="Toggle theme"
+      icon={<SwitchIcon />}
+      onClick={toggleColorMode}
+      variant="outline"
+    />
+  );
+};
+
+export default ThemeToggle;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,10 @@
+import { extendTheme, ThemeConfig } from '@chakra-ui/react';
+
+const config: ThemeConfig = {
+  initialColorMode: 'light',
+  useSystemColorMode: false,
+};
+
+const theme = extendTheme({ config });
+
+export default theme;


### PR DESCRIPTION
## Summary
- add a basic Chakra UI theme configuration
- implement a `ThemeToggle` component
- include the toggle in the popup header

## Testing
- `yarn test`
- `yarn lint` *(fails: 12 errors, 16 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685f01d2ebe08325a7606cf35226343c